### PR TITLE
move twilio account info to `config.ini`

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 from selenium import webdriver
+import configparser
 import sys
 import time
 from selenium.webdriver.support.ui import WebDriverWait
@@ -7,12 +8,12 @@ from selenium.webdriver.support import expected_conditions as EC
 from twilio.rest import TwilioRestClient
 from datetime import datetime
 
-# Change the four following variables appropriately.
-# account_sid and auth_token can be found at https://www.twilio.com/console.
-account_sid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-auth_token = "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY"
-fromNumber = "+1123456789"
-toNumber = "+1123456789"
+config = configparser.SafeConfigParser()
+config.read('config.ini')
+account_sid = config.get('twilio', 'account_sid')
+auth_token = config.get('twilio', 'auth_token')
+fromNumber = config.get('twilio', 'fromNumber')
+toNumber = config.get('twilio', 'toNumber')
 
 def main(argv):
     # Get the command line arguments.

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,7 @@
+[twilio]
+# Change the four following variables appropriately.
+# account_sid and auth_token can be found at https://www.twilio.com/console.
+account_sid = ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+auth_token = YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY
+fromNumber = +1123456789
+toNumber = +1123456789


### PR DESCRIPTION
This moves the twilio account information to a separate, standard
text `.ini` file.  This way, users do not have to change the
actual script, and also it keeps private information separate from
app logic.