### PR TITLE
add a dict of SWA airport codes

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,6 +16,38 @@ AUTH_TOKEN = CONFIG['twilio']['auth_token']
 FROM_NUMBER = CONFIG['twilio']['from_number']
 TO_NUMBER = CONFIG['twilio']['to_number']
 
+
+SWA_AIRPORTS = {'BZE': 'Belize City, Belize', 'MEX': 'Mexico City, Mexico', 
+                'BWI': 'Baltimore/Washington, MD', 'MEM': 'Memphis, TN', 'LAS': 'Las Vegas, NV', 
+                'FNT': 'Flint, MI', 'PHL': 'Philadelphia, PA', 'GCM': 'Grand Cayman Island, KY', 
+                'NAS': 'Nassau, Bahamas', 'SAT': 'San Antonio, TX', 'SFO': 'San Francisco, CA', 
+                'PNS': 'Pensacola, FL', 'RDU': 'Raleigh/Durham, NC', 'ROC': 'Rochester, NY', 
+                'MSP': 'Minneapolis/St. Paul (Terminal 2), MN', 'PBI': 'West Palm Beach, FL', 
+                'TPA': 'Tampa, FL', 'ORF': 'Norfolk, VA', 'MCO': 'Orlando, FL', 'STL': 'St. Louis, MO', 
+                'SLC': 'Salt Lake City, UT', 'DAY': 'Dayton, OH', 'RSW': 'Ft. Myers, FL', 
+                'MBJ': 'Montego Bay, Jamaica', 'BOI': 'Boise, ID', 'BHM': 'Birmingham, AL', 
+                'BUR': 'Burbank, CA', 'CUN': 'Cancun, Mexico', 'PIT': 'Pittsburgh, PA', 'ISP': 'Long Island/Islip, NY', 
+                'FLL': 'Ft. Lauderdale, FL', 'MDW': 'Chicago (Midway), IL', 'ECP': 'Panama City Beach, FL', 
+                'CLT': 'Charlotte, NC', 'CHS': 'Charleston, SC', 'AUA': 'Aruba, Aruba', 'DEN': 'Denver, CO', 
+                'PVR': 'Puerto Vallarta, MX', 'PHX': 'Phoenix, AZ', 'SNA': 'Orange County/Santa Ana, CA', 
+                'VRA': 'Varadero, Cuba', 'ATL': 'Atlanta, GA', 'SMF': 'Sacramento, CA', 'HOU': 'Houston (Hobby), TX', 
+                'ONT': 'Ontario/LA, CA', 'RNO': 'Reno/Tahoe, NV', 'SEA': 'Seattle/Tacoma, WA', 'BDL': 'Hartford, CT', 
+                'LGA': 'New York (LaGuardia), NY', 'CAK': 'Akron-Canton, OH', 'CMH': 'Columbus, OH', 'TUS': 'Tucson, AZ', 
+                'PVD': 'Providence, RI', 'DAL': 'Dallas (Love Field), TX', 'ICT': 'Wichita, KS', 'DTW': 'Detroit, MI', 
+                'LIR': 'Liberia, Costa Rica', 'SJC': 'San Jose, CA', 'MSY': 'New Orleans, LA', 'SDF': 'Louisville, KY', 
+                'OMA': 'Omaha, NE', 'RIC': 'Richmond, VA', 'CRP': 'Corpus Christi, TX', 'EWR': 'New York/Newark, NJ', 
+                'ELP': 'El Paso, TX', 'MCI': 'Kansas City, MO', 'PWM': 'Portland, ME', 'SJU': 'San Juan, PR', 
+                'SJD': 'Cabo San Lucas/Los Cabos, MX', 'BUF': 'Buffalo/Niagara, NY', 'ABQ': 'Albuquerque, NM', 
+                'DCA': 'Washington (Reagan National), DC', 'DSM': 'Des Moines, IA', 'GEG': 'Spokane, WA', 
+                'JAX': 'Jacksonville, FL', 'AUS': 'Austin, TX', 'SAN': 'San Diego, CA', 'CLE': 'Cleveland, OH', 
+                'OKC': 'Oklahoma City, OK', 'MHT': 'Manchester, NH', 'GRR': 'Grand Rapids, MI', 
+                'HAV': 'Havana, Cuba', 'BOS': 'Boston Logan, MA', 'SJO': 'San Jose, Costa Rica', 
+                'ALB': 'Albany, NY', 'AMA': 'Amarillo, TX', 'IAD': 'Washington (Dulles), DC', 'HRL': 'Harlingen, TX', 
+                'OAK': 'Oakland, CA', 'LAX': 'Los Angeles, CA', 'LBB': 'Lubbock, TX', 'GSP': 'Greenville/Spartanburg, SC', 
+                'LIT': 'Little Rock, AR', 'PDX': 'Portland, OR', 'PUJ': 'Punta Cana, DO', 'BNA': 'Nashville, TN', 
+                'SNU': 'Santa Clara, Cuba', 'IND': 'Indianapolis, IN', 'LGB': 'Long Beach, CA', 'MKE': 'Milwaukee, WI', 
+                'MAF': 'Midland/Odessa, TX', 'TUL': 'Tulsa, OK', 'CVG': 'Cincinnati, OH'}
+
 def main():
     """
     Perform a search on southwest.com for the given flight parameters.
@@ -38,13 +70,15 @@ def parse_args():
         "--depart",
         "-d",
         type=str,
-        help="Origin airport code.")
+        help="Origin airport code.",
+        choices = list(SWA_AIRPORTS.keys()))
 
     parser.add_argument(
         "--arrive",
         "-a",
         type=str,
-        help="Destination airport code.")
+        help="Destination airport code.",
+        choices = list(SWA_AIRPORTS.keys()))
 
     parser.add_argument(
         "--departure-date",


### PR DESCRIPTION
I added a dictionary of valid airport codes and their lexical names as reported on www.southwest.com. 
I used Beautiful soup 4 to parse out the names, so everything should be here. 
I also added it as the choices keyword for the origin and destination so that there was some basic error checking there. 

Obviously, this will need to be updated if southwest adds an airport or removes an airport, but that won't happen often and the dict is easily editable now that it exists.